### PR TITLE
Feature/fixups

### DIFF
--- a/main.go
+++ b/main.go
@@ -165,7 +165,7 @@ func (suggestion suggestionCreate) GetEmbed(owner string) webhooks.Embed {
 	if !suggestion.Anonymous {
         embed.Fields = append(embed.Fields, &webhooks.EmbedField{
             Name:  "Suggestion Author",
-            Value: fmt.Sprintf("<@!%v>", suggestion.Owner),
+            Value: fmt.Sprintf("<@!%v>", owner),
         })
 	}
 

--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func (s *suggestionsServer) sendSuggestionHandler(w http.ResponseWriter, r *http
 		return
 	}
 
-	if suggestion.Anonymous {
+	if suggestionCreateData.Anonymous {
         embed.Fields = append(embed.Fields, &webhooks.EmbedField{
             Name:  "Suggestion Author",
             Value: fmt.Sprintf("<@!%v>", suggestion.Owner),

--- a/main.go
+++ b/main.go
@@ -117,10 +117,12 @@ func (s *suggestionsServer) sendSuggestionHandler(w http.ResponseWriter, r *http
 		return
 	}
 
-	embed.Fields = append(embed.Fields, &webhooks.EmbedField{
-		Name:  "Suggestion Author",
-		Value: fmt.Sprintf("<@!%v>", suggestion.Owner),
-	})
+	if suggestion.Anonymous {
+        embed.Fields = append(embed.Fields, &webhooks.EmbedField{
+            Name:  "Suggestion Author",
+            Value: fmt.Sprintf("<@!%v>", suggestion.Owner),
+        })
+    }
 	s.suggestionsLoggingWebhook.SendEmbed(embed)
 
 	s.Update(suggestion.Identifier, false, suggestionCreateData.JsonString())


### PR DESCRIPTION
Adds a new `host` startup param, keeps the submitter consistent in both webhook destinations

Tested, seems to be working.
Probably a better way to go about this, though - could use DRY'ing up with the other TODO's