### PR TITLE
Update build_and_deploy workflow to 0.12.3

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -147,3 +147,5 @@ jobs:
             }
           ]'
         if: env.WORKFLOW_CONCLUSION == 'failure' || env.WORKFLOW_CONCLUSION == 'timed_out'
+
+# forced_update_count: 1


### PR DESCRIPTION
This PR was automatically triggered due to [a change in the base `build_and_deploy` workflow](https://github.com/CFC-Servers/github_action_workflows/compare/0.12.2..0.12.3)